### PR TITLE
Asserting partials modification

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -632,7 +632,7 @@ WARNING: You must include the "layouts" directory name even if you save your lay
 If your view renders any partial, when asserting for the layout, you can to assert for the partial at the same time.
 Otherwise, assertion will fail.
 
-Remember, we added the "_form" partial to our creating Articles view? Let's write an assertion for that in the `:new` action now:
+Remember, we added the "_form" partial to our new Article view? Let's write an assertion for that in the `:new` action now:
 
 ```ruby
 test "new should render correct layout" do


### PR DESCRIPTION
Changed "create Articles view" to "new article view". The create action doesn't typically have a view assigned to it. The view that's being referred to is the 'new' Article view.
